### PR TITLE
Add a MonadRec instance for Optlicative

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,6 +31,7 @@
     "purescript-record": "^1.0.0",
     "purescript-typelevel-prelude": "^3.0.0",
     "purescript-node-process": "^6.0.0",
-    "purescript-console": "^4.1.0"
+    "purescript-console": "^4.1.0",
+    "purescript-tailrec": "^4.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -25,6 +25,7 @@
     "tests"
   ],
   "dependencies": {
+
     "purescript-foreign": "^5.0.0",
     "purescript-validation": "^4.0.0",
     "purescript-record": "^1.0.0",

--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,6 @@
     "tests"
   ],
   "dependencies": {
-
     "purescript-foreign": "^5.0.0",
     "purescript-validation": "^4.0.0",
     "purescript-record": "^1.0.0",

--- a/src/Node/Optlicative/Types.purs
+++ b/src/Node/Optlicative/Types.purs
@@ -2,19 +2,56 @@ module Node.Optlicative.Types where
 
 import Prelude
 
+import Control.Monad.Rec.Class (class MonadRec, Step(..))
 import Control.Alt (class Alt)
 import Control.Alternative (class Alternative)
 import Control.Plus (class Plus)
+import Data.Either (Either(..))
 import Data.List (List, singleton)
 import Data.Maybe (Maybe)
 import Data.Newtype (class Newtype)
-import Data.Validation.Semigroup (V, isValid, invalid)
+import Data.Validation.Semigroup (V, invalid, isValid, toEither)
 
-newtype Optlicative a = Optlicative (OptState -> Result a)
+newtype Optlicative a = Optlicative (OptState -> { state :: OptState, val :: V (List OptError) a })
 
 derive instance newtypeOptlicative :: Newtype (Optlicative a) _
 
 derive instance functorOptlicative :: Functor Optlicative
+
+instance monadRecOptlicative :: MonadRec Optlicative where
+    tailRecM f z = Optlicative \optstate -> tailRec (f z) optstate 
+      where
+        tailRec p@(Optlicative o) optstate = loop (step (o optstate))
+          where
+            loop (Done r) = r
+            loop (Loop { state, val }) =
+              case toEither val of
+                Left e      -> { state, val: invalid e}
+                Right value -> 
+                  let
+                    (Optlicative a1) = f value
+                  in
+                    loop (step (a1 state))
+
+            step :: forall a b. Result (Step a b) -> Step (Result a) (Result b)
+            step { state, val } = case toEither val of
+              Left e         -> Done { state, val: invalid e }
+              Right (Loop v) -> Loop { state, val: pure v }
+              Right (Done v) -> Done { state, val: pure v }
+
+instance bindOptlicative :: Bind Optlicative where
+  bind (Optlicative f) g = Optlicative \s -> 
+    let
+      { state, val } = f s
+    in case toEither val of
+         Left e  -> { state, val: invalid e}
+         Right v -> 
+           let
+             (Optlicative b) = g v
+           in
+             b state
+
+instance monadOptlicative :: Monad Optlicative
 
 instance applyOptlicative :: Apply Optlicative where
   apply (Optlicative f) (Optlicative a) = Optlicative \ s ->

--- a/src/Node/Optlicative/Types.purs
+++ b/src/Node/Optlicative/Types.purs
@@ -12,7 +12,7 @@ import Data.Maybe (Maybe)
 import Data.Newtype (class Newtype)
 import Data.Validation.Semigroup (V, invalid, isValid, toEither)
 
-newtype Optlicative a = Optlicative (OptState -> { state :: OptState, val :: V (List OptError) a })
+newtype Optlicative a = Optlicative (OptState -> Result a)
 
 derive instance newtypeOptlicative :: Newtype (Optlicative a) _
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -4,7 +4,7 @@ import Prelude
 
 import Effect (Effect)
 import Effect.Console (log)
-import Data.List (length)
+import Data.List (length, manyRec)
 import Data.Maybe (Maybe(..), maybe)
 import Data.Validation.Semigroup (unV)
 import Node.Commando (Opt(Opt))
@@ -19,8 +19,9 @@ configRec =
   }
 
 optOne :: Optlicative Config
-optOne = (\ output help -> ConfigOne {output, help})
+optOne = (\ output names help -> ConfigOne {output, names, help})
   <$> string "output" Nothing
+  <*> manyRec (string "name" Nothing)
   <*> flag "help" (Just 'h')
 
 optTwo :: Optlicative Config
@@ -43,9 +44,10 @@ myPrefs = defaultPreferences {globalOpts = globalConfig}
 -- | 3. `pulp test -- one --output blah`
 -- | 4. `pulp test -- one two`
 -- | 5. `pulp test -- one two --help`
--- | 5. `pulp test -- --version`
--- | 6. `pulp test -- --version --say doh`
--- | 7. `pulp test`
+-- | 6. `pulp test -- one --name "Parnell" --name "Stephanie"
+-- | 7. `pulp test -- --version`
+-- | 8. `pulp test -- --version --say doh`
+-- | 9. `pulp test`
 main :: Effect Unit
 main = do
   {cmd, value} <- optlicate configRec myPrefs

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -44,7 +44,7 @@ myPrefs = defaultPreferences {globalOpts = globalConfig}
 -- | 3. `pulp test -- one --output blah`
 -- | 4. `pulp test -- one two`
 -- | 5. `pulp test -- one two --help`
--- | 6. `pulp test -- one --name "Parnell" --name "Stephanie"
+-- | 6. `pulp test -- one --name "John" --name "Bob" --name "Billy"
 -- | 7. `pulp test -- --version`
 -- | 8. `pulp test -- --version --say doh`
 -- | 9. `pulp test`

--- a/test/Types.purs
+++ b/test/Types.purs
@@ -2,6 +2,7 @@ module Test.Types where
 
 import Prelude
 import Node.Commando (Opt)
+import Data.List (List, fold)
 
 type ConfigRec =
   ( one :: Opt Config
@@ -20,9 +21,10 @@ showConfig (GlobalConfig {help, version, say}) =
   "help: " <> show help <> ", " <>
   "version: " <> show version <> ", " <>
   "say: " <> say
-showConfig (ConfigOne {output, help}) =
+showConfig (ConfigOne {output, names, help}) =
   "ConfigOne parsed: \n" <>
   "output: " <> output <> ", " <>
+  "names: " <> fold names <> ", " <>
   "help: " <> show help
 showConfig (ConfigTwo {color, help}) =
   "ConfigTwo parsed: \n" <>
@@ -37,6 +39,7 @@ type GlobalConfig =
 
 type ConfigOne =
   { output :: String
+  , names :: List String
   , help :: Boolean
   }
 


### PR DESCRIPTION
This change introduces a [`MonadRec`](https://pursuit.purescript.org/packages/purescript-tailrec/4.0.0/docs/Control.Monad.Rec.Class#t:MonadRec) instance for the `Optlicative` type.

The motivation for this change came from the desire to apply an Optlicative parser `many` or `some` times, collecting the results in a `forall a. List a`.

For example, given the following command line options:

```
$ myprog --name "john" --name "bob" --name "billy"
```

... I wanted to parse multiple instances of the `--name STRING` option into a `List String`. The `purescript-lists` package provides a [`manyRec`](https://pursuit.purescript.org/packages/purescript-lists/5.0.0/docs/Data.List#v:manyRec) combinator (and `someRec`) specifically for applying an applicative zero or more times and collecting the results in a `List` but in order to ensure stack-safety it requires a `MonadRec` instance.