### PR TITLE
Add a non-generic `many` combinator

### DIFF
--- a/src/Node/Optlicative.purs
+++ b/src/Node/Optlicative.purs
@@ -118,6 +118,8 @@ optional (Optlicative o) = Optlicative \ s ->
   let {state, val} = o s
   in  {state, val: if isValid val then Just <$> val else pure Nothing}
 
+-- | Apply an `Optlicative` parser zero or more times, collecting the
+-- | results in a `List`.
 many :: forall a. Optlicative a -> Optlicative (List a)
 many parser = Optlicative \optstate -> go parser optstate Nil
   where

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -8,7 +8,7 @@ import Data.List (length)
 import Data.Maybe (Maybe(..), maybe)
 import Data.Validation.Semigroup (unV)
 import Node.Commando (Opt(Opt))
-import Node.Optlicative (Optlicative, Preferences, defaultPreferences, flag, logErrors, optlicate, string)
+import Node.Optlicative (Optlicative, Preferences, defaultPreferences, flag, logErrors, optlicate, string, many)
 import Test.Types (Config(..), ConfigRec, showConfig)
 
 configRec :: Record ConfigRec
@@ -19,8 +19,9 @@ configRec =
   }
 
 optOne :: Optlicative Config
-optOne = (\ output help -> ConfigOne {output, help})
+optOne = (\ output names help -> ConfigOne {output, names, help})
   <$> string "output" Nothing
+  <*> many (string "name" Nothing)
   <*> flag "help" (Just 'h')
 
 optTwo :: Optlicative Config
@@ -44,8 +45,10 @@ myPrefs = defaultPreferences {globalOpts = globalConfig}
 -- | 4. `pulp test -- one two`
 -- | 5. `pulp test -- one two --help`
 -- | 5. `pulp test -- --version`
--- | 6. `pulp test -- --version --say doh`
--- | 7. `pulp test`
+-- | 6. `pulp test -- one --name "John" --name "Bob" --name "Billy"
+-- | 7. `pulp test -- --version`
+-- | 8. `pulp test -- --version --say doh`
+-- | 9. `pulp test`
 main :: Effect Unit
 main = do
   {cmd, value} <- optlicate configRec myPrefs

--- a/test/Types.purs
+++ b/test/Types.purs
@@ -2,6 +2,7 @@ module Test.Types where
 
 import Prelude
 import Node.Commando (Opt)
+import Data.List (List, fold)
 
 type ConfigRec =
   ( one :: Opt Config
@@ -20,9 +21,10 @@ showConfig (GlobalConfig {help, version, say}) =
   "help: " <> show help <> ", " <>
   "version: " <> show version <> ", " <>
   "say: " <> say
-showConfig (ConfigOne {output, help}) =
+showConfig (ConfigOne {output, names, help}) =
   "ConfigOne parsed: \n" <>
   "output: " <> output <> ", " <>
+  "names: " <> fold names <> ", " <>
   "help: " <> show help
 showConfig (ConfigTwo {color, help}) =
   "ConfigTwo parsed: \n" <>
@@ -37,6 +39,7 @@ type GlobalConfig =
 
 type ConfigOne =
   { output :: String
+  , names :: List String
   , help :: Boolean
   }
 


### PR DESCRIPTION
This change introduces a simple `many` combinator for the `Optlicative` type.

The motivation for this change came from the desire to apply an Optlicative parser `many` times, collecting the results in a `forall a. List a`.

For example, given the following command line options:

```
$ myprog --name "john" --name "bob" --name "billy"
```

... I wanted to parse multiple instances of the `--name STRING` option into a `List String`. 

This change was my first stab at implementing this requirement, then I produced #4 thinking the more general solution was better but retracted that PR because it added illegal instances.