### PR TITLE
Update for PureScript 0.13 compatibility

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,6 @@
     "purescript-foreign": "^5.0.0",
     "purescript-validation": "^4.0.0",
     "purescript-record": "^2.0.0",
-    "purescript-typelevel-prelude": "^4.0.0",
     "purescript-node-process": "^7.0.0",
     "purescript-console": "^4.1.0"
   }

--- a/src/Node/Commando.purs
+++ b/src/Node/Commando.purs
@@ -12,29 +12,31 @@ import Data.Maybe (Maybe(..))
 import Data.Symbol (class IsSymbol, SProxy(..), reflectSymbol)
 import Node.Optlicative.Types (Optlicative)
 import Record (delete, get)
-import Type.Row (class Lacks, class RowToList, class Cons, Cons, Nil, RLProxy(..), kind RowList)
+import Prim.Row as R
+import Prim.RowList as RL
+import Type.Data.RowList (RLProxy(..))
 
 class RLCommando
-  (rl :: RowList)
+  (rl :: RL.RowList)
   (row :: # Type)
   (a :: Type)
   | rl -> row
   where
     rlCommando :: RLProxy rl -> Record row -> List String -> Maybe {cmd :: String, opt :: Optlicative a}
 
-instance basisRlHelp :: RLCommando Nil () a where
+instance basisRlHelp :: RLCommando RL.Nil () a where
   rlCommando _ _ _ = Nothing
 
 instance ihRlHelp ::
   ( IsSymbol k -- key in row of IH case
   , RLCommando tail rowtail a -- IH
   , RLCommando list' row' a -- also IH, for 2nd arg which is a row
-  , Cons k (Opt a row') rowtail row -- row = rowtail U Opt
-  , Lacks k rowtail
-  , RowToList rowtail tail -- rowtail <-> tail
-  , RowToList row (Cons k (Opt a row') tail) -- row <-> list
-  , RowToList row' list' -- row' <-> list'
-  ) => RLCommando (Cons k (Opt a row') tail) row a where
+  , R.Cons k (Opt a row') rowtail row -- row = rowtail U Opt
+  , R.Lacks k rowtail
+  , RL.RowToList rowtail tail -- rowtail <-> tail
+  , RL.RowToList row (RL.Cons k (Opt a row') tail) -- row <-> list
+  , RL.RowToList row' list' -- row' <-> list'
+  ) => RLCommando (RL.Cons k (Opt a row') tail) row a where
 
     rlCommando _ rec args@(cmd : Nil) =
       let
@@ -64,7 +66,7 @@ class Commando (row :: # Type) a where
   commando :: Record row -> List String -> Maybe {cmd :: String, opt :: Optlicative a}
 
 instance rowHelpInst ::
-  ( RowToList row list
+  ( RL.RowToList row list
   , RLCommando list row a
   ) => Commando row a where
     commando rec xs = rlCommando (RLProxy :: RLProxy list) rec xs


### PR DESCRIPTION
Technically this is a breaking change since it's removing a dependency, but this is how we've been fixing the core libraries for PS 0.13 and then releasing them with a patch bump to minimise friction.

Also in this case, `-typelevel-prelude` is still included transitively (just, with a version range now), so it definitely isn't breaking. 🙂 